### PR TITLE
Update state_attr.js

### DIFF
--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -417,7 +417,7 @@ const state_attrb = {
 	},
 	'k': {
 		'name': 'K',
-		'type': 'number',
+		'type': 'mixed',
 		'role': 'state'
 	},
 	'lifecycle': {


### PR DESCRIPTION
Temporary fix for 'State value to set for "bambulab.xxx.k" has to be type "number" but received type "string"'