### PR TITLE
feat: add H2C printer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ The location of the API token and serial number depends on your printer model:
 2. The access token is directly visible in network settings
 3. Serial number can be found in the same menu or in device information
 
-**Note:** You must select your Printer model correctly in the adapter settings. Only the X1 series allows pushing of messages, P1x series needs to request by interval setting (default every 5 seconds)
+**Note:** You must select your Printer model correctly in the adapter settings. X1 and H2 series push messages after the initial request, while P1x series needs to request by interval setting (default every 5 seconds).
 
 ## Supported models
 | Printer-Model | Status                  |
 |---------------|-------------------------|
 | AMS           | :white_check_mark:      |
 | A1            | :white_check_mark:      |
+| H2C           | :white_check_mark:      |
 | P1p           | :white_check_mark:      |
 | P1s           | :white_check_mark:      |
 | X1            | :white_check_mark:      |
@@ -94,6 +95,7 @@ All of this helps me to provide error-free adapters that basically never crash.
 	### **WORK IN PROGRESS**
 -->
 ### **WORK IN PROGRESS**
+* Add H2C local MQTT support, firmware discovery and dual-nozzle temperatures
 * (DutchmanNL & Copilot) Update all dependencies to latest versions, consolidating 17 Dependabot PRs
 * (DutchmanNL & Copilot) Synchronize admin translations with jsonConfig.json - add missing translations and remove orphaned keys (#202)
 

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "API-Token aus den Drucker-Netzwerkeinstellungen - siehe README für detaillierte Anweisungen je Druckermodell",
     "Access Token": "Zugangs-Token",
     "Device serial number from printer network settings - required for authentication": "Geräte-Seriennummer aus den Drucker-Netzwerkeinstellungen - erforderlich für Authentifizierung",
+    "H2C-Series": "H2C-Serie",
     "H2D-Series": "H2D-Serie",
     "Here you can upload files, like g-code, to send to the printer": "Hier können Sie Dateien, wie z. B. G-Code, hochladen, um sie an den Drucker zu senden",
     "Message buffer": "Nachrichtenpuffer",

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -3,6 +3,7 @@
 	"API token from printer network settings - see README for detailed instructions per printer model": "API token from printer network settings - see README for detailed instructions per printer model",
 	"Access Token": "Access Token",
 	"Device serial number from printer network settings - required for authentication": "Device serial number from printer network settings - required for authentication",
+	"H2C-Series": "H2C-Series",
 	"H2D-Series": "H2D-Series",
 	"Here you can upload files, like g-code, to send to the printer": "Here you can upload files, like g-code, to send to the printer",
 	"Message buffer": "Message buffer",

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "Token API de la configuración de red de la impresora - consulte el README para instrucciones detalladas según el modelo de impresora",
     "Access Token": "Token de acceso",
     "Device serial number from printer network settings - required for authentication": "Número de serie del dispositivo de la configuración de red de la impresora - requerido para la autenticación",
+    "H2C-Series": "Serie H2C",
     "H2D-Series": "Serie H2D",
     "Here you can upload files, like g-code, to send to the printer": "Aquí puede cargar archivos, como G-Code, para enviarlos a la impresora",
     "Message buffer": "Búfer de mensajes",

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "Jeton API des paramètres réseau de l'imprimante - voir le README pour des instructions détaillées selon le modèle d'imprimante",
     "Access Token": "Access Token",
     "Device serial number from printer network settings - required for authentication": "Numéro de série de l'appareil depuis les paramètres réseau de l'imprimante - requis pour l'authentification",
+    "H2C-Series": "Série H2C",
     "H2D-Series": "Série H2D",
     "Here you can upload files, like g-code, to send to the printer": "Ici vous pouvez télécharger des fichiers, comme le G-Code, pour les envoyer à l'imprimante",
     "Message buffer": "Tampon de messages",

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "Token API dalle impostazioni di rete della stampante - vedere il README per istruzioni dettagliate per modello di stampante",
     "Access Token": "Access Token",
     "Device serial number from printer network settings - required for authentication": "Numero di serie del dispositivo dalle impostazioni di rete della stampante - richiesto per l'autenticazione",
+    "H2C-Series": "Serie H2C",
     "H2D-Series": "Serie H2D",
     "Here you can upload files, like g-code, to send to the printer": "Qui puoi caricare file, come G-Code, da inviare alla stampante",
     "Message buffer": "Buffer dei messaggi",

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "API-token uit de netwerkinstellingen van de printer - zie README voor gedetailleerde instructies per printermodel",
     "Access Token": "Access Token",
     "Device serial number from printer network settings - required for authentication": "Serienummer van het apparaat uit de netwerkinstellingen van de printer - vereist voor authenticatie",
+    "H2C-Series": "H2C-serie",
     "H2D-Series": "H2D-serie",
     "Here you can upload files, like g-code, to send to the printer": "Hier kunt u bestanden, zoals G-code, uploaden om naar de printer te sturen",
     "Message buffer": "Berichtenbuffer",

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "Token API z ustawień sieciowych drukarki – zobacz README po szczegółowe instrukcje dla każdego modelu drukarki",
     "Access Token": "Token dostępu",
     "Device serial number from printer network settings - required for authentication": "Numer seryjny urządzenia z ustawień sieciowych drukarki – wymagany do uwierzytelnienia",
+    "H2C-Series": "Seria H2C",
     "H2D-Series": "Seria H2D",
     "Here you can upload files, like g-code, to send to the printer": "Tutaj możesz przesłać pliki, takie jak G-Code, aby wysłać je do drukarki",
     "Message buffer": "Bufor wiadomości",

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "Token da API das configurações de rede da impressora - veja o README para instruções detalhadas por modelo de impressora",
     "Access Token": "Access Token",
     "Device serial number from printer network settings - required for authentication": "Número de série do dispositivo das configurações de rede da impressora - necessário para autenticação",
+    "H2C-Series": "Série H2C",
     "H2D-Series": "Série H2D",
     "Here you can upload files, like g-code, to send to the printer": "Aqui você pode carregar arquivos, como G-Code, para enviar à impressora",
     "Message buffer": "Buffer de mensagens",

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "API-токен из сетевых настроек принтера — см. README для подробных инструкций по каждой модели принтера",
     "Access Token": "Токен доступа",
     "Device serial number from printer network settings - required for authentication": "Серийный номер устройства из сетевых настроек принтера — требуется для аутентификации",
+    "H2C-Series": "Серия H2C",
     "H2D-Series": "Серия H2D",
     "Here you can upload files, like g-code, to send to the printer": "Здесь вы можете загрузить файлы, такие как G-Code, для отправки на принтер",
     "Message buffer": "Буфер сообщений",

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "API-токен з налаштувань мережі принтера – дивіться README для детальних інструкцій для кожної моделі принтера",
     "Access Token": "Токен доступу",
     "Device serial number from printer network settings - required for authentication": "Серійний номер пристрою з налаштувань мережі принтера – необхідний для автентифікації",
+    "H2C-Series": "Серія H2C",
     "H2D-Series": "Серія H2D",
     "Here you can upload files, like g-code, to send to the printer": "Тут ви можете завантажити файли, такі як G-Code, для відправки на принтер",
     "Message buffer": "Буфер повідомлень",

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -3,6 +3,7 @@
     "API token from printer network settings - see README for detailed instructions per printer model": "来自打印机网络设置的 API 令牌——请参阅 README 获取各型号打印机的详细说明",
     "Access Token": "Access Token",
     "Device serial number from printer network settings - required for authentication": "来自打印机网络设置的设备序列号——认证时必需",
+    "H2C-Series": "H2C系列",
     "H2D-Series": "H2D系列",
     "Here you can upload files, like g-code, to send to the printer": "您可以在此上传文件（如G代码）以发送到打印机",
     "Message buffer": "消息缓冲区",

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -49,6 +49,10 @@
                     "value": "A1-Series"
                 },
                 {
+                    "label": "H2C-Series",
+                    "value": "H2C-Series"
+                },
+                {
                     "label": "H2D-Series",
                     "value": "H2D-Series"
                 },

--- a/h2.test.js
+++ b/h2.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { expect } = require('chai');
+const { canonicalizeSerial, decodeH2NozzleTemperatures } = require('./lib/h2');
+
+describe('H2 printer protocol helpers', () => {
+    it('canonicalizes the serial used in case-sensitive MQTT topics', () => {
+        expect(canonicalizeSerial(' 31b8dp632100385 ')).to.equal('31B8DP632100385');
+    });
+
+    it('decodes live H2C dual-nozzle temperature words', () => {
+        expect(
+            decodeH2NozzleTemperatures([
+                { id: 0, temp: 16056565 },
+                { id: 1, temp: 2621493 },
+            ]),
+        ).to.deep.equal({
+            right_nozzle_temper: 245,
+            right_nozzle_target_temper: 245,
+            left_nozzle_temper: 53,
+            left_nozzle_target_temper: 40,
+        });
+    });
+
+    it('ignores unknown extruders and invalid values', () => {
+        expect(
+            decodeH2NozzleTemperatures([
+                { id: 2, temp: 123 },
+                { id: 0, temp: '123' },
+            ]),
+        ).to.deep.equal({});
+        expect(decodeH2NozzleTemperatures(undefined)).to.deep.equal({});
+    });
+});

--- a/h2.test.js
+++ b/h2.test.js
@@ -1,7 +1,12 @@
 'use strict';
 
 const { expect } = require('chai');
-const { canonicalizeSerial, decodeH2NozzleTemperatures } = require('./lib/h2');
+const {
+    canonicalizeSerial,
+    decodeH2NozzleTemperatures,
+    decodeH2TemperatureWord,
+    decodeH2ChamberTemperatures,
+} = require('./lib/h2');
 
 describe('H2 printer protocol helpers', () => {
     it('canonicalizes the serial used in case-sensitive MQTT topics', () => {
@@ -30,5 +35,20 @@ describe('H2 printer protocol helpers', () => {
             ]),
         ).to.deep.equal({});
         expect(decodeH2NozzleTemperatures(undefined)).to.deep.equal({});
+    });
+
+    it('decodes live H2C chamber target and current temperatures', () => {
+        // Observed on an H2C: 0x0041003c = target 65 °C, current 60 °C.
+        expect(decodeH2TemperatureWord(0x0041003c)).to.deep.equal({ current: 60, target: 65 });
+        expect(decodeH2ChamberTemperatures(0x0041003c)).to.deep.equal({
+            chamber_temper: 60,
+            chamber_target_temper: 65,
+        });
+    });
+
+    it('rejects invalid or implausible packed temperature words', () => {
+        expect(decodeH2TemperatureWord('4259900')).to.equal(null);
+        expect(decodeH2TemperatureWord(0x0200003c)).to.equal(null);
+        expect(decodeH2ChamberTemperatures(undefined)).to.deep.equal({});
     });
 });

--- a/lib/h2.js
+++ b/lib/h2.js
@@ -27,4 +27,42 @@ function decodeH2NozzleTemperatures(extruders) {
     return temperatures;
 }
 
-module.exports = { canonicalizeSerial, decodeH2NozzleTemperatures };
+/**
+ * H2 chamber/bed temperature words store the target in the high 16 bits and
+ * the current temperature in the low 16 bits.
+ *
+ * @param {unknown} temperatureWord - Packed unsigned 32-bit temperature word.
+ * @returns {{current: number, target: number} | null} Decoded temperatures, or null for invalid input.
+ */
+function decodeH2TemperatureWord(temperatureWord) {
+    if (typeof temperatureWord !== 'number' || !Number.isInteger(temperatureWord)) {
+        return null;
+    }
+
+    const current = temperatureWord & 0xffff;
+    const target = (temperatureWord >>> 16) & 0xffff;
+    // Temperatures outside the physical printer range indicate a different
+    // field layout or a sentinel value and must not become ioBroker states.
+    if (current > 500 || target > 500) {
+        return null;
+    }
+    return { current, target };
+}
+
+/** @param {unknown} temperatureWord - H2 device.ctc.info.temp value. */
+function decodeH2ChamberTemperatures(temperatureWord) {
+    const decoded = decodeH2TemperatureWord(temperatureWord);
+    return decoded
+        ? {
+              chamber_temper: decoded.current,
+              chamber_target_temper: decoded.target,
+          }
+        : {};
+}
+
+module.exports = {
+    canonicalizeSerial,
+    decodeH2NozzleTemperatures,
+    decodeH2TemperatureWord,
+    decodeH2ChamberTemperatures,
+};

--- a/lib/h2.js
+++ b/lib/h2.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/** @param {unknown} serial - Configured printer serial number. */
+function canonicalizeSerial(serial) {
+    return String(serial || '')
+        .trim()
+        .toUpperCase();
+}
+
+/** @param {Array<{id?: number, temp?: unknown}> | undefined} extruders - H2 extruder status entries. */
+function decodeH2NozzleTemperatures(extruders) {
+    const temperatures = {};
+    if (!Array.isArray(extruders)) {
+        return temperatures;
+    }
+    for (const extruder of extruders) {
+        const temperatureWord = extruder?.temp;
+        if (typeof temperatureWord !== 'number' || !Number.isInteger(temperatureWord)) {
+            continue;
+        }
+        const side = extruder.id === 0 ? 'right' : extruder.id === 1 ? 'left' : null;
+        if (side) {
+            temperatures[`${side}_nozzle_temper`] = temperatureWord & 0xffff;
+            temperatures[`${side}_nozzle_target_temper`] = (temperatureWord >>> 16) & 0xffff;
+        }
+    }
+    return temperatures;
+}
+
+module.exports = { canonicalizeSerial, decodeH2NozzleTemperatures };

--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -1,4 +1,11 @@
 const state_attrb = {
+    flag: { name: 'Module flags', type: 'number', role: 'value' },
+    hw_ver: { name: 'Hardware version', type: 'string', role: 'text' },
+    loader_ver: { name: 'Loader version', type: 'string', role: 'text' },
+    name: { name: 'Module name', type: 'string', role: 'text' },
+    product_name: { name: 'Product name', type: 'string', role: 'text' },
+    sw_ver: { name: 'Software version', type: 'string', role: 'text' },
+    visible: { name: 'Module visible', type: 'boolean', role: 'indicator' },
     cooling_fan_speed: {
         name: 'Cooling fan Speed',
         modify: ['TOINTEGER'],
@@ -83,6 +90,30 @@ const state_attrb = {
         role: 'level.temperature',
         write: true,
         modify: ['TOFLOAT'],
+    },
+    left_nozzle_temper: {
+        name: 'Left nozzle current temperature',
+        type: 'number',
+        unit: '°C',
+        role: 'value.temperature',
+    },
+    left_nozzle_target_temper: {
+        name: 'Left nozzle target temperature',
+        type: 'number',
+        unit: '°C',
+        role: 'value.temperature',
+    },
+    right_nozzle_temper: {
+        name: 'Right nozzle current temperature',
+        type: 'number',
+        unit: '°C',
+        role: 'value.temperature',
+    },
+    right_nozzle_target_temper: {
+        name: 'Right nozzle target temperature',
+        type: 'number',
+        unit: '°C',
+        role: 'value.temperature',
     },
     chamber_temper: {
         name: 'Chamber Temperature',
@@ -614,7 +645,7 @@ const state_attrb = {
     },
     err_code: {
         name: 'Error Code',
-        type: 'number',
+        type: 'mixed',
         role: 'value',
     },
     ext_new_version_number: {
@@ -957,7 +988,7 @@ const state_attrb = {
     },
     tar_id: {
         name: 'Target ID',
-        type: 'string',
+        type: 'mixed',
         role: 'text',
     },
     tar_name: {

--- a/lib/state_attr.js
+++ b/lib/state_attr.js
@@ -122,6 +122,12 @@ const state_attrb = {
         role: 'value.temperature',
         modify: ['TOFLOAT'],
     },
+    chamber_target_temper: {
+        name: 'Chamber target temperature',
+        type: 'number',
+        unit: '°C',
+        role: 'value.temperature',
+    },
     nozzle_temper: {
         name: 'Nozzle current Temperature',
         type: 'number',

--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ const { default: axios } = require('axios'); // Http request library
 const jsonExplorer = require('iobroker-jsonexplorer'); // Use jsonExplorer library
 const convert = require('./lib/converter'); // Load converter functions
 const stateAttr = require(`${__dirname}/lib/state_attr.js`); // Load attribute library
-const { canonicalizeSerial, decodeH2NozzleTemperatures } = require('./lib/h2');
+const { canonicalizeSerial, decodeH2NozzleTemperatures, decodeH2ChamberTemperatures } = require('./lib/h2');
 
 let client; // Memory to store client connection information
 const clientConnection = {
@@ -240,6 +240,7 @@ class Bambulab extends utils.Adapter {
 
             if (message.print) {
                 Object.assign(message.print, decodeH2NozzleTemperatures(message.print.device?.extruder?.info));
+                Object.assign(message.print, decodeH2ChamberTemperatures(message.print.device?.ctc?.info?.temp));
 
                 // Modify values of JSON for states which need modification
                 message.print.control = {};

--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ const { default: axios } = require('axios'); // Http request library
 const jsonExplorer = require('iobroker-jsonexplorer'); // Use jsonExplorer library
 const convert = require('./lib/converter'); // Load converter functions
 const stateAttr = require(`${__dirname}/lib/state_attr.js`); // Load attribute library
+const { canonicalizeSerial, decodeH2NozzleTemperatures } = require('./lib/h2');
 
 let client; // Memory to store client connection information
 const clientConnection = {
@@ -124,18 +125,20 @@ class Bambulab extends utils.Adapter {
                 this.createControlStates();
 
                 // Subscribe on a printer topic after connection
-                client.subscribe([`device/${this.config.serial}/report`], () => {
-                    this.log.debug(`Subscribed to printer data topic by serial | ${this.config.serial}`);
+                const mqttSerial = canonicalizeSerial(this.config.serial);
+                client.subscribe([`device/${mqttSerial}/report`], () => {
+                    this.log.debug(`Subscribed to printer data topic by serial | ${mqttSerial}`);
+                    this.requestVersion();
+                    this.requestData();
                 });
-
-                // After new firmware release this summer all data must be requested 1 time at adapter start
-                this.requestData();
             });
 
             // Receive MQTT messages
-            client.on('message', (topic, message) => {
+            client.on('message', async (topic, message) => {
                 // Parse string to an JSON object
-                message = JSON.parse(message.toString());
+                const parsedMessage = JSON.parse(message.toString());
+                message = parsedMessage;
+                const printerInfo = parsedMessage.info;
 
                 // @ts-expect-error if print does not exist function will return false and skip
                 if (message && message.print && message && message.print.result) {
@@ -145,7 +148,10 @@ class Bambulab extends utils.Adapter {
                 } else if (message && message.print) {
                     this.log.debug(`Printer Message ${JSON.stringify(message)}`);
                     this.messageHandler(message);
-                    // @ts-expect-error if system does not exist function will return false and skip
+                } else if (printerInfo && printerInfo.command === 'get_version') {
+                    this.log.debug(`Printer version message ${JSON.stringify(message)}`);
+                    await jsonExplorer.traverseJson(printerInfo, `${this.config.serial}.firmware`, false, false, 0);
+                    // @ts-expect-error if command does not exist function will return false and skip
                 } else if (message && message.command) {
                     this.log.info(`Response to control command ${JSON.stringify(message)}`);
                     // @ts-expect-error if system does not exist function will return false and skip
@@ -233,46 +239,7 @@ class Bambulab extends utils.Adapter {
             }
 
             if (message.print) {
-                try {
-                    this.log.debug(`Extruder R temp: ${message.print.device.extruder.info[0].temp}`);
-                } catch {
-                    // Ignore if extruder info is not available
-                }
-
-                try {
-                    this.log.debug(
-                        `Extruder R temp decoded: ${decodeExtruderTemp(message.print.device.extruder.info[0].temp)}`,
-                    );
-                } catch {
-                    // Ignore if extruder info is not available
-                }
-
-                try {
-                    this.log.debug(`Extruder L temp: ${message.print.device.extruder.info[1].temp}`);
-                } catch {
-                    // Ignore if extruder info is not available
-                }
-
-                try {
-                    this.log.debug(
-                        `Extruder L temp decoded: ${decodeExtruderTemp(message.print.device.extruder.info[1].temp)}`,
-                    );
-                } catch {
-                    // Ignore if extruder info is not available
-                }
-
-                try {
-                    this.log.debug(`Nozzel temp: ${decodeExtruderTemp(message.print.nozzle_temper)}`);
-                } catch {
-                    // Ignore if nozzle_temper is not available
-                }
-
-                function decodeExtruderTemp(raw) {
-                    if (raw > 500) {
-                        return Math.round(raw / 58100);
-                    }
-                    return raw; // Already realistic
-                }
+                Object.assign(message.print, decodeH2NozzleTemperatures(message.print.device?.extruder?.info));
 
                 // Modify values of JSON for states which need modification
                 message.print.control = {};
@@ -473,7 +440,7 @@ class Bambulab extends utils.Adapter {
     publishMQTTmessages(msg) {
         this.log.debug(`Publish message ${JSON.stringify(msg)}`);
 
-        const topic = `device/${this.config.serial}/request`;
+        const topic = `device/${canonicalizeSerial(this.config.serial)}/request`;
         client.publish(topic, JSON.stringify(msg), { qos: 0, retain: false }, error => {
             if (error) {
                 console.error(error);
@@ -485,10 +452,9 @@ class Bambulab extends utils.Adapter {
         // Prepare MQTT message
         const msg = {
             pushing: {
-                sequence_id: '1',
+                sequence_id: '0',
                 command: 'pushall',
             },
-            user_id: '1234567890',
         };
 
         // Try to request data
@@ -505,6 +471,10 @@ class Bambulab extends utils.Adapter {
                 this.requestData();
             }
         }, this.config.requestInterval * 1000);
+    }
+
+    requestVersion() {
+        this.publishMQTTmessages({ info: { sequence_id: '0', command: 'get_version' } });
     }
 
     createControlStates() {


### PR DESCRIPTION
## Summary

- canonicalize printer serials for case-sensitive MQTT topics
- add H2C model selection and current `get_version` / `pushall` initialization
- expose firmware/module information
- decode H2C dual-nozzle current and target temperatures
- accept H2 payload type variants for `err_code` and `tar_id`

## Validation

Tested live with a Bambu Lab H2C on firmware 01.02.00.00 using local MQTT. The adapter created more than 700 printer, AMS and hotend-rack objects. Progress, layers, bed temperature, and both nozzle current/target temperatures were compared against the Home Assistant Bambu integration and matched exactly.

- `npm test`: 23 JS tests and 57 package tests pass
- `npm run lint`: passes
- includes unit tests using anonymized live H2C packed temperature words

`npm run check` currently also reports pre-existing project/dependency errors on unmodified lines (missing `@tsconfig/node14`, converter return types, ioBroker dependency resolution, and an existing state-value type mismatch). The H2C additions do not add further typecheck errors.