### PR TITLE
fix: restore JavaScript type checking

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -154,17 +154,8 @@ function speedProfile(value) {
  * @param {any} value - The remaining time value to parse
  */
 function remainingTime(value) {
-    let hour = Math.floor((value % 3600) / 60);
-    let minute = Math.floor(value % 60);
-
-    //Den String von Stunden, Minuten und Sekunden auf 2 Stellen ändern
-    if (hour < 10) {
-        hour = `0${hour}`;
-    }
-
-    if (minute < 10) {
-        minute = `0${minute}`;
-    }
+    const hour = String(Math.floor((value % 3600) / 60)).padStart(2, '0');
+    const minute = String(Math.floor(value % 60)).padStart(2, '0');
 
     value = `${hour}:${minute}`;
 

--- a/main.js
+++ b/main.js
@@ -660,7 +660,7 @@ class Bambulab extends utils.Adapter {
                 this.log.info(`No Local translation available, version ${onlineTran.ver} downloaded`);
                 this.setStateAsync(`info.hmsErrorCodeTranslations`, { val: JSON.stringify(onlineTranObj), ack: true });
                 await loadTranslationsToMemory(onlineTranObj);
-            } else if (currentTran.val != null && currentTran.val !== '') {
+            } else if (typeof currentTran.val === 'string' && currentTran.val !== '') {
                 const currentTranObj = JSON.parse(currentTran.val);
                 // Check if new version is available
                 if (currentTranObj.ver !== onlineTran.ver) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 // Root tsconfig to set the settings and power editor support for all TS files
 {
 	// To update the compilation target, install a different version of @tsconfig/node... and reference it here
-	// https://github.com/tsconfig/bases#node-14-tsconfigjson
-	"extends": "@tsconfig/node14/tsconfig.json",
+	// https://github.com/tsconfig/bases#node-18-tsconfigjson
+	"extends": "@tsconfig/node18/tsconfig.json",
 	"compilerOptions": {
 		// do not compile anything, this file is just to configure type checking
 		"noEmit": true,


### PR DESCRIPTION
## Summary
- align the root TypeScript config with the installed `@tsconfig/node18` package
- format remaining time without mixing number and string types
- narrow the persisted HMS translation state before `JSON.parse`

## Verification
- `npm run check`
- `npm run lint`
- `npm test`

All checks pass locally.